### PR TITLE
Add travis-ci for gamma-sky

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+# This is the travis-ci configuration file for gamma-sky.net
+# Some notes are at the end of this file.
+
+sudo: required
+dist: trusty
+language: node_js
+node_js:
+  - '6'
+
+addons:
+apt:
+  sources:
+    - google-chrome
+  packages:
+    - google-chrome-stable
+    - google-chrome-beta
+
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+
+before_script:
+- npm install -g angular-cli
+- npm install -g karma
+- npm install
+- ng build
+
+script: karma start config/karma.conf.js --single-run
+
+
+# We use conda to install the Python dependencies
+# following the instructions here:
+# http://conda.pydata.org/docs/travis.html#using-conda-with-travis-ci
+#
+# And we install Node and the NPM dependencies
+# following the instructions here:
+# https://medium.com/from-the-couch/angular-2-with-travis-ci-922040e01937#.4mevdjoqc
+# See also:
+# https://github.com/antonybudianto/angular2-starter/blob/master/.travis.yml
+# https://github.com/mgechev/angular2-seed/blob/master/.travis.yml

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@ A portal to the gamma-ray sky
 * Webpage: http://gamma-sky.net/
 * Repository: https://github.com/gammapy/gamma-sky
 * Documentation: https://github.com/gammapy/gamma-sky/wiki
+* [![Build Status](https://travis-ci.org/gammapy/gamma-sky.svg?branch=master)](https://travis-ci.org/gammapy/gamma-sky)

--- a/src/app/gamma-sky.component.spec.ts
+++ b/src/app/gamma-sky.component.spec.ts
@@ -15,8 +15,8 @@ describe('App: GammaSky', () => {
     expect(app).toBeTruthy();
   }));
 
-  it('should have as title \'gamma-sky works!\'',
+  it('should have as title \'GammaSkyAppComponent\'',
       inject([GammaSkyAppComponent], (app: GammaSkyAppComponent) => {
-    expect(app.title).toEqual('gamma-sky works!');
+    expect(app.title).toEqual('GammaSkyAppComponent');
   }));
 });


### PR DESCRIPTION
This pull request adds a travis-ci configuration file `.travis.yml`.
From now on, tests will be run for every pull request with results here:
https://travis-ci.org/gammapy/gamma-sky/

I will leave the installation of the Python dependencies 
http://conda.pydata.org/docs/travis.html#using-conda-with-travis-ci
and running the static web page build scripts to a future pull request.
