### PR TITLE
update surveys dropdown with our own surveys

### DIFF
--- a/src/app/data/maps/surveys.ts
+++ b/src/app/data/maps/surveys.ts
@@ -1,0 +1,30 @@
+
+class Survey {
+  "id": string;
+  "url": string;
+  "name": string;
+  "maxOrder": number;
+  "frame": string;
+  "format": string;
+}
+
+export var SURVEYS: Survey[] = [
+
+  {
+    "id": "P/Fermi/color",
+    "url": "http://alasky.u-strasbg.fr/Fermi/Color",
+    "name": "Fermi color",
+    "maxOrder": 3,
+    "frame": "equatorial",
+    "format": "jpeg"
+  },
+  {
+    "id": "P/Haslam408",
+    "url": "http://alasky.u-strasbg.fr/Haslam408",
+    "name": "Haslam 408",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "jpeg fits",
+  }
+
+]

--- a/src/app/widgets/map/map.component.ts
+++ b/src/app/widgets/map/map.component.ts
@@ -3,9 +3,11 @@ import { Popup } from '../popup/popup';
 // import { ViewEncapsulation } from '@angular/core';
 
 import {CatalogService} from '../../services/catalog.service';
+import {SURVEYS} from '../../data/maps/surveys';
 
 
 declare var A: any;
+declare var HpxImageSurvey: any;
 declare var $: any;
 
 @Component({
@@ -35,6 +37,12 @@ export class MapComponent implements OnInit, OnDestroy {
       showShareControl: true, //Hidden attribute, not yet working
       // showCatalog: false //Hidden attribute
     });
+  }
+
+  updateSurveys() {
+    setTimeout(() => {
+      HpxImageSurvey.SURVEYS = SURVEYS;
+    }, 1000);
   }
 
   addCatalog(catalogName, catalogColor, data) {
@@ -188,6 +196,8 @@ export class MapComponent implements OnInit, OnDestroy {
     console.log('aladin map OnInit');
 
     this.showMap();
+
+    this.updateSurveys();
 
     this.getCatalog3FGL();
     this.getCatalog2FHL();


### PR DESCRIPTION
@cdeil - In this PR I've configured the "Base image layer" dropdown to just display two relevant surveys. The surveys are defined in a SURVEYS[] variable, inside the data folder.
