### PR TITLE
Add images to surveys.ts

### DIFF
--- a/src/app/data/maps/surveys.ts
+++ b/src/app/data/maps/surveys.ts
@@ -8,6 +8,12 @@ class Survey {
   "format": string;
 }
 
+// Database of available surveys (in HiPS file format): http://aladin.unistra.fr/hips/list
+
+// **Note: Some of the links for each survey DO NOT work in browser, but will still load an image in Aladin Lite.
+//         Conversely, some of the survey links do work but the image will not appear on Aladin Lite.
+//         Therefore, check each survey that you add to the list below.
+
 export var SURVEYS: Survey[] = [
 
   {

--- a/src/app/data/maps/surveys.ts
+++ b/src/app/data/maps/surveys.ts
@@ -25,6 +25,65 @@ export var SURVEYS: Survey[] = [
     "maxOrder": 3,
     "frame": "galactic",
     "format": "jpeg fits",
+  },
+  {
+    "id": "P/PLANCK/LFI/color",
+    "url": "http://alasky.u-strasbg.fr/PLANCK/R2/LFI_Color_30_44_70",
+    "name": "Planck R2 LFI Color 30-44-70 GHz",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "jpeg"
+  },
+  {
+    "id": "P/PLANCK/HFI/color",
+    "url": "http://alasky.u-strasbg.fr/PLANCK/HFIColor353-545-857",
+    "name": "Planck R1 HFI Color 353-545-857 GHz",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "jpeg"
+  },
+  {
+    "id": "P/PLANCK/R2/HFI/color",
+    "url": "http://alasky.u-strasbg.fr/PLANCK/R2/HFI_Color_353_545_857",
+    "name": "Planck R2 HFI Color 353-545-857 GHz",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "jpeg"
+  },
+  {
+    "id": "P/GLIMPSE360",
+    "url": "http://www.spitzer.caltech.edu/glimpse360/aladin/data",
+    "name": "GLIMPSE360",
+    "maxOrder": 9,
+    "frame": "equatorial",
+    "format": "jpeg"
+  },
+  {
+    "id": "P/IRIS/4",
+    "url": "http://cade.irap.omp.eu/documents/Ancillary/4Aladin/IRIS_4",
+    "name": "IRIS Band 4-100um",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "jpeg fits"
+  },
+  {
+    "id": "P/CGPS/VGPS/CONT",
+    "url": "http://cade.irap.omp.eu/documents/Ancillary/4Aladin/CGPS_VGPS_CONT/",
+    "name": "CGPS-VGPS CONT",
+    "maxOrder": 4,
+    "frame": "galactic",
+    "format": "jpeg fits"
+  },
+  {
+    "id": "P/AKARI/WideS",
+    "url": "http://cade.irap.omp.eu/documents/Ancillary/4Aladin/AKARI_WideS",
+    "name": "AKARI 90um",
+    "maxOrder": 3,
+    "frame": "galactic",
+    "format": "png jpeg fits"
   }
+
+
+
 
 ]

--- a/src/app/data/maps/surveys.ts
+++ b/src/app/data/maps/surveys.ts
@@ -53,7 +53,7 @@ export var SURVEYS: Survey[] = [
   {
     "id": "P/GLIMPSE360",
     "url": "http://www.spitzer.caltech.edu/glimpse360/aladin/data",
-    "name": "GLIMPSE360",
+    "name": "Spitzer GLIMPSE360",
     "maxOrder": 9,
     "frame": "equatorial",
     "format": "jpeg"


### PR DESCRIPTION
These are the 7 surveys added in this PR, recommended by Nachi:
- [Planck R2 LFI](http://alasky.u-strasbg.fr/PLANCK/R2/LFI_Color_30_44_70)
- [Planck R1 HFI](http://alasky.u-strasbg.fr/PLANCK/HFIColor353-545-857)
- [Planck R2 HFI](http://alasky.u-strasbg.fr/PLANCK/R2/HFI_Color_353_545_857)
- [Spitzer's GLIMPSE360](http://www.spitzer.caltech.edu/glimpse360/aladin/data)
- [IRIS](http://cade.irap.omp.eu/documents/Ancillary/4Aladin/IRIS_4)
- [CGPS](http://cade.irap.omp.eu/documents/Ancillary/4Aladin/CGPS_VGPS_CONT/)
- [AKARI](http://cade.irap.omp.eu/documents/Ancillary/4Aladin/AKARI_WideS)

One more that Nachi recommended was [this Planck HFI image](http://irsa.ipac.caltech.edu/data/Planck/release_1/all-sky-maps/previews/HFI_SkyMap_857_2048_R1.10_nominal/index.html), but we would have to convert the FITS file to HiPS ourselves.
