### PR TITLE
Configure source detail pages for TeV catalog

### DIFF
--- a/gammasky/catalogs.py
+++ b/gammasky/catalogs.py
@@ -8,6 +8,7 @@ from astropy.table import Table
 import json
 from gammapy.catalog import SourceCatalog3FHL, SourceCatalogGammaCat, SourceCatalog3FGL
 from .utils import table_to_list_of_dict, dump_to_json
+from .config import DATA_DIR
 
 __all__ = [
     'make_tev_catalog_data',
@@ -21,11 +22,10 @@ __all__ = [
 
 TO_JSON_KWARGS = dict(orient='split', double_precision=5)
 
-
 def make_3fhl_catalog_data():
     click.secho('Making 3FHL catalog data...', fg='green')
 
-    out_dir = Path('src/app/data/cat/3fhl')
+    out_dir = DATA_DIR / 'cat/3fhl'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     cat = SourceCatalog3FHL()
@@ -35,7 +35,7 @@ def make_3fhl_catalog_data():
     cat.table = cat.table[cols]
     data = cat._data_python_list
 
-    filename = 'src/app/data/cat/3fhl/cat.json'
+    filename = out_dir / 'cat.json'
     click.secho('Writing 3fhl {}'.format(filename), fg='green')
     dump_to_json(data, filename)
 
@@ -45,11 +45,11 @@ def make_3fhl_source_data():
 
     cat = SourceCatalog3FHL()
     for source in cat:
-        out_dir = Path('src/app/data/cat/3fhl/sources/{:04d}'.format(source.index))
+        out_dir = DATA_DIR / 'cat/3fhl/sources/{:04d}'.format(source.index)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         data = source._data_python_dict
-        filename = 'src/app/data/cat/3fhl/sources/{:04d}/data.json'.format(source.index)
+        filename = out_dir / 'data.json'
         click.secho('Writing: {}'.format(filename), fg='green')
         dump_to_json(data, filename)
 
@@ -57,7 +57,7 @@ def make_3fhl_source_data():
 def make_tev_catalog_data():
     click.secho('Making TeV catalog data (from gamma-cat)...', fg='green')
 
-    out_dir = Path('src/app/data/cat/tev')
+    out_dir = DATA_DIR / 'cat/tev'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     cat = SourceCatalogGammaCat()
@@ -66,7 +66,7 @@ def make_tev_catalog_data():
     cat.table = cat.table[cols]
     data = cat._data_python_list
 
-    filename = 'src/app/data/cat/tev/cat.json'
+    filename = out_dir / 'cat.json'
     click.secho('Writing tev {}'.format(filename), fg='green')
     dump_to_json(data, filename)
 
@@ -76,11 +76,11 @@ def make_tev_source_data():
 
     cat = SourceCatalogGammaCat()
     for source in cat:
-        out_dir = Path('src/app/data/cat/tev/sources/{:04d}'.format(source.index))
+        out_dir = DATA_DIR / 'cat/tev/sources/{:04d}'.format(source.index)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         data = source._data_python_dict
-        filename = 'src/app/data/cat/tev/sources/{:04d}/data.json'.format(source.index)
+        filename = out_dir / 'data.json'
         click.secho('Writing: {}'.format(filename), fg='green')
         dump_to_json(data, filename)
 
@@ -88,7 +88,7 @@ def make_tev_source_data():
 def make_3fgl_catalog_data():
     click.secho('Making 3FGL catalog data...', fg='green')
 
-    out_dir = Path('src/app/data/cat/3fgl')
+    out_dir = DATA_DIR / 'cat/3fgl'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     cat = SourceCatalog3FGL()
@@ -97,7 +97,7 @@ def make_3fgl_catalog_data():
     cat.table = cat.table[cols]
     data = cat._data_python_list
 
-    filename = 'src/app/data/cat/3fgl/cat.json'
+    filename = out_dir / 'cat.json'
     click.secho('Writing 3fgl {}'.format(filename), fg='green')
     dump_to_json(data, filename)
 
@@ -107,11 +107,11 @@ def make_3fgl_source_data():
 
     cat = SourceCatalog3FGL()
     for source in cat:
-        out_dir = Path('src/app/data/cat/3fgl/sources/{:04d}'.format(source.index))
+        out_dir = DATA_DIR / 'cat/3fgl/sources/{:04d}'.format(source.index)
         out_dir.mkdir(parents=True, exist_ok=True)
 
         data = source._data_python_dict
-        filename = 'src/app/data/cat/3fgl/sources/{:04d}/data.json'.format(source.index)
+        filename = out_dir / 'data.json'
         click.secho('Writing: {}'.format(filename), fg='green')
         dump_to_json(data, filename)
 
@@ -119,7 +119,7 @@ def make_3fgl_source_data():
 def make_snrcat_catalog_data():
     click.secho('Making SNRcat catalog data...', fg='green')
 
-    out_dir = Path('src/app/data/cat/snrcat')
+    out_dir = DATA_DIR / 'cat/snrcat'
     out_dir.mkdir(parents=True, exist_ok=True)
 
     url = 'https://github.com/gammapy/gammapy-extra/blob/master/datasets/catalogs/snrcat.fits.gz?raw=true'
@@ -133,7 +133,7 @@ def make_snrcat_catalog_data():
         ]
     list_of_dict = table_to_list_of_dict(table.filled())
 
-    filename = 'src/app/data/cat/snrcat/cat.json'
+    filename = out_dir / 'cat.json'
     click.secho('Writing SNRcat {}'.format(filename), fg='green')
     with open(filename, 'w') as fh:
         json.dump(list_of_dict, fh)

--- a/gammasky/config.py
+++ b/gammasky/config.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+DATA_DIR = Path('src/data/')

--- a/src/app/services/catalog.service.ts
+++ b/src/app/services/catalog.service.ts
@@ -57,6 +57,27 @@ export class CatalogService {
       .catch(this.handleError);
   }
 
+  getSource3FHL(id) {
+    return this.http.get(this.getSourceDirectory('3fhl', id))
+      .toPromise()
+      .then(response => new Source3FHL( response.json() ))
+      .catch(this.handleError);
+  }
+
+  getSource3FGL(id) {
+    return this.http.get(this.getSourceDirectory('3fgl', id))
+      .toPromise()
+      .then(response => new Source3FGL( response.json() ))
+      .catch(this.handleError);
+  }
+
+  getSourceSNRcat(id) {
+    return this.http.get(this.getSourceDirectory('snrcat', id))
+      .toPromise()
+      .then(response => new SourceSNRcat( response.json() ))
+      .catch(this.handleError);
+  }
+
 
   private handleError(error: any) {
     console.error('An error occurred', error);

--- a/src/app/services/catalog.service.ts
+++ b/src/app/services/catalog.service.ts
@@ -10,8 +10,8 @@ import { CatalogTeV, Catalog3FGL, CatalogSNRcat, Catalog3FHL } from './catalog';
 @Injectable()
 export class CatalogService {
 
+// Fetch catalog data
   getCatalogTeV() {
-    // return this.http.get('app/data/cat/cat_tev.json')
     return this.http.get('data/cat/tev/cat.json')
       .toPromise()
       .then(response => {
@@ -41,6 +41,22 @@ export class CatalogService {
       .then(response => new CatalogSNRcat( response.json(), SourceSNRcat ))
       .catch(this.handleError);
   }
+
+// Fetch source data
+  getSourceDirectory(cat, id) {
+    var str = id.toString();
+    var pad = "0000";
+    var s = pad.substring(0, pad.length - str.length) + str;
+    return `data/cat/${cat}/sources/${s}/data.json`;
+  }
+
+  getSourceTeV(id) {
+    return this.http.get(this.getSourceDirectory('tev', id))
+      .toPromise()
+      .then(response => new SourceTeV( response.json() ))
+      .catch(this.handleError);
+  }
+
 
   private handleError(error: any) {
     console.error('An error occurred', error);

--- a/src/app/services/catalog.service.ts
+++ b/src/app/services/catalog.service.ts
@@ -14,10 +14,7 @@ export class CatalogService {
   getCatalogTeV() {
     return this.http.get('data/cat/tev/cat.json')
       .toPromise()
-      .then(response => {
-        console.log(new CatalogTeV(response.json(), SourceTeV));
-        return new CatalogTeV( response.json(), SourceTeV )
-      })
+      .then(response => new CatalogTeV( response.json(), SourceTeV ))
       .catch(this.handleError);
   }
 

--- a/src/app/services/source.ts
+++ b/src/app/services/source.ts
@@ -6,25 +6,36 @@ class SourceBase {
     this.data = data;
   }
 
-  formatf(val) {
-    // Value has fixed number of digits
-    if(val != null)
-      return val.toFixed(3);
-    else
-      return val;
+  format(val, precision:boolean, unit:String='') {
+    // This method formats every numerical value in the source object data.
+    // Boolean `precision` calls either formatp() (true) or formatf() (false).
+    // No unit is passed by default. If it's wanted, set the parameter.
+    if(val == null) {
+      return this.handle_null();
+    }
+    else {
+      if(precision) {
+        return `${this.formatp(val)} ${unit}`;
+      }
+      else {
+        return `${this.formatf(val)} ${unit}`;
+      }
+    }
+  }
+
+  format_error(val, val_err, precision:boolean, unit:String='') {
+    return `${this.format(val, precision)} +- ${this.format(val_err, precision)} ${unit}`;
   }
 
   formatp(val) {
-    // Value to a certain precision
-    if(val != null)
       return val.toPrecision(3);
-    else
-      return val;
+  }
+  formatf(val) {
+    return val.toFixed(3);
   }
 
-
-  format_error(val, val_err) {
-    return `${this.formatp(val)} +- ${this.formatp(val_err)}`;
+  handle_null() {
+    return "No data";
   }
 
 }
@@ -45,54 +56,53 @@ export class SourceTeV extends SourceBase {
     return this.data.other_names.split(",").join(", ");
   }
 
-  get_spec_parameters() {
-    var spec = this.data.spec_type;
-    var markup;
-
-    if(spec == 'pl') {
-      markup = `
-      <ul>
-        <li>Spectrum type: pl</li>
-        <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
-        <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
-        <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err)} (statistical)</li>
-        <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err_sys)} (systematic)</li>
-        <li>reference: ${this.formatp(this.data.spec_pl_e_ref)}</li>
-      </ul>
-      `;
-    }
-    else if(spec == 'pl2') {
-      markup = `
-      <ul>
-        <li>Spectrum type: pl2 (integral pl)</li>
-        <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err)} cm-2 s-1 (statistical)</li>
-        <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err_sys)} cm-2 s-1 (systematic)</li>
-        <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err)} (statistical)</li>
-        <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err_sys)} (systematic)</li>
-        <li>e_min: ${this.formatp(this.data.spec_pl2_e_min)} TeV</li>
-        <li>e_max: ${this.formatp(this.data.spec_pl2_e_max)} TeV</li>
-      `;
-    }
-    else if(spec == 'ecpl') {
-      markup =`
-      <ul>
-        <li>Spectrum type: ecpl</li>
-        <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
-        <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
-        <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err)} (statistical)</li>
-        <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err_sys)} (systematic)</li>
-        <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err)} TeV (statistical)</li>
-        <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err_sys)} TeV (systematic)</li>
-        <li>reference: ${this.formatp(this.data.spec_ecpl_e_ref)}</li>
-      `;
-    }
-    else {
-      markup = "Spectral model printout not yet implemented.";
-    }
-
-    document.getElementById('spec').innerHTML = markup;
-
-  }
+  // get_spec_parameters() {
+  //   var spec = this.data.spec_type;
+  //   var markup;
+  //
+  //   if(spec == 'pl') {
+  //     markup = `
+  //     <ul>
+  //       <li>Spectrum type: pl</li>
+  //       <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
+  //       <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
+  //       <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err)} (statistical)</li>
+  //       <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err_sys)} (systematic)</li>
+  //       <li>reference: ${this.formatp(this.data.spec_pl_e_ref)}</li>
+  //     </ul>
+  //     `;
+  //   }
+  //   else if(spec == 'pl2') {
+  //     markup = `
+  //     <ul>
+  //       <li>Spectrum type: pl2 (integral pl)</li>
+  //       <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err)} cm-2 s-1 (statistical)</li>
+  //       <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err_sys)} cm-2 s-1 (systematic)</li>
+  //       <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err)} (statistical)</li>
+  //       <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err_sys)} (systematic)</li>
+  //       <li>e_min: ${this.formatp(this.data.spec_pl2_e_min)} TeV</li>
+  //       <li>e_max: ${this.formatp(this.data.spec_pl2_e_max)} TeV</li>
+  //     `;
+  //   }
+  //   else if(spec == 'ecpl') {
+  //     markup =`
+  //     <ul>
+  //       <li>Spectrum type: ecpl</li>
+  //       <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
+  //       <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
+  //       <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err)} (statistical)</li>
+  //       <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err_sys)} (systematic)</li>
+  //       <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err)} TeV (statistical)</li>
+  //       <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err_sys)} TeV (systematic)</li>
+  //       <li>reference: ${this.formatp(this.data.spec_ecpl_e_ref)}</li>
+  //     `;
+  //   }
+  //   else {
+  //     markup = "Spectral model printout not yet implemented.";
+  //   }
+  //
+  //   document.getElementById('spec').innerHTML = markup;
+  // }
 
 }
 

--- a/src/app/services/source.ts
+++ b/src/app/services/source.ts
@@ -42,18 +42,15 @@ class SourceBase {
 
 export class SourceTeV extends SourceBase {
 
-  class_str() {
-    return this.data.classes.split(",").join(", ");
+  comma_space(val) {
+    return val.split(',').join(', ');
   }
 
-  gamma_names_str() {
-    return this.data.gamma_names.split(",").join(", ");
+  get_tevcat_url() {
+    return `http://tevcat.uchicago.edu/?mode=1;id=${this.data.tevcat_id}`;
   }
-  fermi_names_str() {
-    return this.data.fermi_names.split(",").join(", ");
-  }
-  other_names_str() {
-    return this.data.other_names.split(",").join(", ");
+  get_tevcat2_url() {
+    return `http://tevcat2.uchicago.edu/sources/${this.data.tevcat2_id}`;
   }
 
   // get_spec_parameters() {
@@ -117,7 +114,7 @@ export class Source3FGL extends SourceBase {
 export class SourceSNRcat extends SourceBase {
 
   getSNRcatUrl(snrcatId) {
-    return "http://www.physics.umanitoba.ca/snr/SNRcat/SNRrecord.php?id=" + snrcatId;
+    return `http://www.physics.umanitoba.ca/snr/SNRcat/SNRrecord.php?id=${snrcatId}`;
   }
 
 }

--- a/src/app/services/source.ts
+++ b/src/app/services/source.ts
@@ -24,7 +24,12 @@ class SourceBase {
   }
 
   format_error(val, val_err, precision:boolean, unit:String='') {
-    return `${this.format(val, precision)} +- ${this.format(val_err, precision)} ${unit}`;
+    if(val == null) {
+      return this.handle_null();
+    }
+    else {
+      return `${this.format(val, precision)} +/- ${this.format(val_err, precision)} ${unit}`;
+    }
   }
 
   formatp(val) {
@@ -51,6 +56,15 @@ export class SourceTeV extends SourceBase {
   }
   get_tevcat2_url() {
     return `http://tevcat2.uchicago.edu/sources/${this.data.tevcat2_id}`;
+  }
+
+  format_stat_sys(val, err_stat, err_syst, precision:boolean, unit:String='') {
+    if(val == null) {
+      return this.handle_null();
+    }
+    else {
+      return `${this.format(val, precision)} +/- ${this.format(err_stat, precision)} (stat.) +/- ${this.format(err_syst, precision)} (syst.) ${unit}`;
+    }
   }
 
   // get_spec_parameters() {

--- a/src/app/services/source.ts
+++ b/src/app/services/source.ts
@@ -1,53 +1,110 @@
-const pos_precision = 3;
 
-export class SourceTeV {
+class SourceBase {
+
   public data;
   constructor(data) {
     this.data = data;
   }
 
-  // ra_str() {
-  //     return this.ra.toFixed(pos_precision) + ' deg';
-  //   //   return this._pos_with_err_str('RA');
-  // }
-  // dec_str() {
-  //     return this.dec.toFixed(pos_precision) + ' deg';
-  //   //   return this._pos_with_err_str('DEC');
-  // }
-  // glon_str() { return this.glon.toFixed(pos_precision) + ' deg'; }
-  // glat_str() { return this.glat.toFixed(pos_precision) + ' deg'; }
+  formatf(val) {
+    // Value has fixed number of digits
+    if(val != null)
+      return val.toFixed(3);
+    else
+      return val;
+  }
+
+  formatp(val) {
+    // Value to a certain precision
+    if(val != null)
+      return val.toPrecision(3);
+    else
+      return val;
+  }
+
+
+  format_error(val, val_err) {
+    return `${this.formatp(val)} +- ${this.formatp(val_err)}`;
+  }
+
+}
+
+export class SourceTeV extends SourceBase {
 
   class_str() {
     return this.data.classes.split(",").join(", ");
   }
-  other_names_str() {
-    return this.data.other_names.split(",").join(", ");
-  }
+
   gamma_names_str() {
     return this.data.gamma_names.split(",").join(", ");
   }
+  fermi_names_str() {
+    return this.data.fermi_names.split(",").join(", ");
+  }
+  other_names_str() {
+    return this.data.other_names.split(",").join(", ");
+  }
+
+  get_spec_parameters() {
+    var spec = this.data.spec_type;
+    var markup;
+
+    if(spec == 'pl') {
+      markup = `
+      <ul>
+        <li>Spectrum type: pl</li>
+        <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
+        <li>norm: ${this.format_error(this.data.spec_pl_norm, this.data.spec_pl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
+        <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err)} (statistical)</li>
+        <li>index: ${this.format_error(this.data.spec_pl_index, this.data.spec_pl_index_err_sys)} (systematic)</li>
+        <li>reference: ${this.formatp(this.data.spec_pl_e_ref)}</li>
+      </ul>
+      `;
+    }
+    else if(spec == 'pl2') {
+      markup = `
+      <ul>
+        <li>Spectrum type: pl2 (integral pl)</li>
+        <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err)} cm-2 s-1 (statistical)</li>
+        <li>flux: ${this.format_error(this.data.spec_pl2_flux, this.data.spec_pl2_flux_err_sys)} cm-2 s-1 (systematic)</li>
+        <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err)} (statistical)</li>
+        <li>index: ${this.format_error(this.data.spec_pl2_index, this.data.spec_pl2_index_err_sys)} (systematic)</li>
+        <li>e_min: ${this.formatp(this.data.spec_pl2_e_min)} TeV</li>
+        <li>e_max: ${this.formatp(this.data.spec_pl2_e_max)} TeV</li>
+      `;
+    }
+    else if(spec == 'ecpl') {
+      markup =`
+      <ul>
+        <li>Spectrum type: ecpl</li>
+        <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err)} cm-2 s-1 TeV-1 (statistical)</li>
+        <li>norm: ${this.format_error(this.data.spec_ecpl_norm, this.data.spec_ecpl_norm_err_sys)} cm-2 s-1 TeV-1 (systematic)</li>
+        <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err)} (statistical)</li>
+        <li>index: ${this.format_error(this.data.spec_ecpl_index, this.data.spec_ecpl_index_err_sys)} (systematic)</li>
+        <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err)} TeV (statistical)</li>
+        <li>e_cut: ${this.format_error(this.data.spec_ecpl_e_cut, this.data.spec_ecpl_e_cut_err_sys)} TeV (systematic)</li>
+        <li>reference: ${this.formatp(this.data.spec_ecpl_e_ref)}</li>
+      `;
+    }
+    else {
+      markup = "Spectral model printout not yet implemented.";
+    }
+
+    document.getElementById('spec').innerHTML = markup;
+
+  }
 
 }
 
-export class Source3FHL {
-  public data;
-  constructor(data) {
-    this.data = data;
-  }
+export class Source3FHL extends SourceBase {
+
 }
 
-export class Source3FGL {
-  public data;
-  constructor(data) {
-    this.data = data;
-  }
+export class Source3FGL extends SourceBase {
+
 }
 
-export class SourceSNRcat {
-  public data;
-  constructor(data) {
-    this.data = data;
-  }
+export class SourceSNRcat extends SourceBase {
 
   getSNRcatUrl(snrcatId) {
     return "http://www.physics.umanitoba.ca/snr/SNRcat/SNRrecord.php?id=" + snrcatId;

--- a/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.html
@@ -2,10 +2,10 @@
   <div class="container">
 
     <div class="col-md-4">
-        <h3>{{getSource().Source_Name}}</h3>
+        <h3>{{source.data.Source_Name}}</h3>
         <h5>Basic info: </h5>
         <ul>
-          <li>Source Name: {{getSource().Source_Name}}</li>
+          <li>Source Name: {{source.data.Source_Name}}</li>
         </ul>
 
         <!-- <ul>
@@ -28,12 +28,12 @@
 
     <div class="col-md-4">
       <h3>Lightcurve</h3>
-      <img src="{{getUrl(getSource().Source_Name, 'lc')}}" class="img-responsive" alt="Light curve" />
+      <img src="{{getUrl(source.data.Source_Name, 'lc')}}" class="img-responsive" alt="Light curve" />
     </div>
 
     <div class="col-md-4">
       <h3>Spectrum</h3>
-      <img src="{{getUrl(getSource().Source_Name, 'spec')}}" class="img-responsive" alt="Spectrum" />
+      <img src="{{getUrl(source.data.Source_Name, 'spec')}}" class="img-responsive" alt="Spectrum" />
     </div>
 
   </div>

--- a/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.html
@@ -2,10 +2,10 @@
   <div class="container">
 
     <div class="col-md-4">
-        <h3>{{source.data.Source_Name}}</h3>
+        <h3>{{d.Source_Name}}</h3>
         <h5>Basic info: </h5>
         <ul>
-          <li>Source Name: {{source.data.Source_Name}}</li>
+          <li>Source Name: {{d.Source_Name}}</li>
         </ul>
 
         <!-- <ul>
@@ -28,12 +28,12 @@
 
     <div class="col-md-4">
       <h3>Lightcurve</h3>
-      <img src="{{getUrl(source.data.Source_Name, 'lc')}}" class="img-responsive" alt="Light curve" />
+      <img src="{{getUrl(d.Source_Name, 'lc')}}" class="img-responsive" alt="Light curve" />
     </div>
 
     <div class="col-md-4">
       <h3>Spectrum</h3>
-      <img src="{{getUrl(source.data.Source_Name, 'spec')}}" class="img-responsive" alt="Spectrum" />
+      <img src="{{getUrl(d.Source_Name, 'spec')}}" class="img-responsive" alt="Spectrum" />
     </div>
 
   </div>

--- a/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
@@ -14,6 +14,7 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
 
   private sub;
   private id;
+  private d;
 
   private catalog: Catalog3FGL;
   private source: Source3FGL;
@@ -27,7 +28,10 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
 
   getSource() {
     this.catalogService.getSource3FGL(this.id)
-      .then(source => { this.source = source; })
+      .then(source => {
+        this.source = source;
+        this.d = source.data;
+      })
       .catch (error => this.error = error);
   }
 

--- a/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
@@ -69,8 +69,6 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
   ngOnInit() {
     console.log("Routing to CatSource3FGLComponent...");
 
-    this.getCatalog();
-
     this.sub = this.activatedRoute.params.subscribe(params => {
         let id = +params['id'];
         console.log('id ', id);
@@ -78,6 +76,7 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
         this.getSource();
     });
 
+    this.getCatalog();
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fgl/cat-source-3fgl.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import { Catalog3FGL } from '../../../services/catalog';
+import { Source3FGL } from '../../../services/source';
 import { CatalogService } from '../../../services/catalog.service';
 
 @Component({
@@ -13,21 +14,21 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
 
   private sub;
   private id;
-  private source;
 
   private catalog: Catalog3FGL;
+  private source: Source3FGL;
   private error: any;
 
   getCatalog() {
     this.catalogService.getCatalog3FGL()
-      .then(catalog => {
-        this.catalog = catalog;
-      })
+      .then(catalog => { this.catalog = catalog; })
       .catch(error => this.error = error);
   }
 
   getSource() {
-    return this.catalog.getSource(this.id);
+    this.catalogService.getSource3FGL(this.id)
+      .then(source => { this.source = source; })
+      .catch (error => this.error = error);
   }
 
   getUrl(sourceName, image) {
@@ -74,6 +75,7 @@ export class CatSource3FGLComponent implements OnInit, OnDestroy {
         let id = +params['id'];
         console.log('id ', id);
         this.id = id;
+        this.getSource();
     });
 
   }

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
@@ -1,10 +1,10 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{source.data.Source_Name}}</h3>
+      <h3>{{d.Source_Name}}</h3>
       <h5>Basic info: </h5>
       <ul>
-        <li>Source name: {{source.data.Source_Name}}</li>
+        <li>Source name: {{d.Source_Name}}</li>
       </ul>
     </div>
   </div>

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
@@ -1,10 +1,10 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{getSource().Source_Name}}</h3>
+      <h3>{{source.data.Source_Name}}</h3>
       <h5>Basic info: </h5>
       <ul>
-        <li>Source name: {{getSource().Source_Name}}</li>
+        <li>Source name: {{source.data.Source_Name}}</li>
       </ul>
     </div>
   </div>

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import { Catalog3FHL } from '../../../services/catalog';
+import { Source3FHL } from '../../../services/source';
 import { CatalogService } from '../../../services/catalog.service';
 
 @Component({
@@ -13,9 +14,9 @@ export class CatSource3FHLComponent implements OnInit {
 
   private sub;
   private id;
-  private source;
 
   private catalog: Catalog3FHL;
+  private source: Source3FHL;
   private error: any;
 
   getCatalog() {
@@ -25,7 +26,9 @@ export class CatSource3FHLComponent implements OnInit {
   }
 
   getSource() {
-    return this.catalog.getSource(this.id);
+    this.catalogService.getSource3FHL(this.id)
+      .then(source => { this.source = source; })
+      .catch (error => this.error = error);
   }
 
   constructor(
@@ -42,6 +45,7 @@ export class CatSource3FHLComponent implements OnInit {
       let id = +params['id'];
       console.log('id ', id);
       this.id = id;
+      this.getSource();
     });
 
   }

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
@@ -14,6 +14,7 @@ export class CatSource3FHLComponent implements OnInit {
 
   private sub;
   private id;
+  private d;
 
   private catalog: Catalog3FHL;
   private source: Source3FHL;
@@ -27,7 +28,10 @@ export class CatSource3FHLComponent implements OnInit {
 
   getSource() {
     this.catalogService.getSource3FHL(this.id)
-      .then(source => { this.source = source; })
+      .then(source => {
+        this.source = source;
+        this.d = source.data;
+      })
       .catch (error => this.error = error);
   }
 

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
@@ -39,8 +39,6 @@ export class CatSource3FHLComponent implements OnInit {
   ngOnInit() {
     console.log("Routing to CatSource3FHLComponent...");
 
-    this.getCatalog();
-
     this.sub = this.activatedRoute.params.subscribe(params => {
       let id = +params['id'];
       console.log('id ', id);
@@ -48,6 +46,7 @@ export class CatSource3FHLComponent implements OnInit {
       this.getSource();
     });
 
+    this.getCatalog();
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/cat-source/cat-source-snrcat/cat-source-snrcat.component.ts
+++ b/src/app/widgets/cat-source/cat-source-snrcat/cat-source-snrcat.component.ts
@@ -14,7 +14,6 @@ export class CatSourceSNRcatComponent implements OnInit {
 
   private sub;
   private id;
-  // private source;
 
   private catalog: CatalogSNRcat;
   private error: any;

--- a/src/app/widgets/cat-source/cat-source-snrcat/cat-source-snrcat.component.ts
+++ b/src/app/widgets/cat-source/cat-source-snrcat/cat-source-snrcat.component.ts
@@ -44,7 +44,6 @@ export class CatSourceSNRcatComponent implements OnInit {
   ngOnInit() {
     console.log("Routing to CatSourceSNRcatComponent...");
 
-    this.getCatalog();
 
     this.sub = this.activatedRoute.params.subscribe(params => {
       let id = +params['id'];
@@ -52,6 +51,7 @@ export class CatSourceSNRcatComponent implements OnInit {
       this.id = id;
     });
 
+    this.getCatalog();
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -1,28 +1,105 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{d.common_name}}</h3>
+      <h2>{{d.common_name}}</h2><br>
 
-      <h5>Basic info</h5>
+      <h4><b>Basic Info</b></h4>
       <ul>
         <li>Common name: {{d.common_name}}</li>
-      </ul>
-      <!-- <ul>
-          <li>Common name: {{getSource().data.Source_Name}}</li>
-          <li>Gamma names: {{getSource().gamma_names_str()}}</li>
-          <li>Other names: {{getSource().other_names_str()}}</li>
-          <li>Class: {{getSource().class_str()}}</li>
-          <li>TODO: add link to TeVCat</li>
-          <li>TODO: add link to get data as JSON</li>
+        <li>Gamma names: {{source.gamma_names_str()}}</li>
+        <li>Fermi names: {{source.fermi_names_str()}}</li>
+        <li>Other names: {{source.other_names_str()}}</li>
+        <!-- TODO: Combine the three above into one "Other names"? -->
+        <li>Location: {{d.where}}</li>
+        <li>Class: {{source.class_str()}}</li>
+        <br>
+        <li>TeVCat ID: {{d.tevcat_id}}</li>
+        <li>TevCat2 ID: {{d.tevcat2_id}}</li>
+        <li>TeVCat name: {{d.tevcat_name}}</li>
+        <br>
+        <li>TGeVCat ID: {{d.tgevcat_id}}</li>
+        <li>TGeVCat name: {{d.tgevcat_name}}</li>
+        <br>
+        <li>Discoverer: {{d.discoverer}}</li>
+        <li>Discovery date: {{d.discovery_date}}</li>
+        <li>Seen by: {{d.seen_by}}</li>
+        <li>Reference: {{d.reference_id}}</li>
       </ul>
 
-      <h5>Position info:</h5>
+      <br>
+      <h4><b>Position Info</b></h4>
+      <p>
+        <u>SIMBAD</u>
+      </p>
       <ul>
-          <li>RA: {{getSource().ra_str()}}</li>
-          <li>DEC: {{getSource().dec_str()}}</li>
-          <li>GLON: {{getSource().glon_str()}}</li>
-          <li>GLAT: {{getSource().glat_str()}}</li>
-      </ul> -->
+        <li>RA: {{source.formatf(d.ra)}} deg</li>
+        <li>DEC: {{source.formatf(d.dec)}} deg</li>
+        <li>GLON: {{source.formatf(d.glon)}} deg</li>
+        <li>GLAT: {{source.formatf(d.glat)}} deg</li>
+      </ul>
+      <p>
+        <u>Measurement</u>
+      </p>
+      <ul>
+        <li>RA: {{source.formatf(d.pos_ra)}} deg</li>
+        <li>DEC: {{source.formatf(d.pos_dec)}} deg</li>
+        <li>GLON: {{source.formatf(d.pos_glon)}} deg</li>
+        <li>GLAT: {{source.formatf(d.pos_glat)}} deg</li>
+        <li>Position error: {{source.formatf(d.pos_err)}} deg</li>
+      </ul>
+
+      <br>
+      <h4><b>Morphology Info</b></h4>
+      <ul>
+        <li>Morphology model type: {{d.morph_type}}</li>
+        <li>Sigma: {{source.formatf(d.morph_sigma)}} deg</li>
+        <li>Sigma error: {{source.formatf(d.morph_sigma_err)}} deg</li>
+        <li>Sigma2: {{source.formatf(d.morph_sigma2)}} deg</li>
+        <li>Sigma2 error: {{source.formatf(d.morph_sigma2_err)}} deg</li>
+        <li>Position angle: {{source.formatf(d.morph_pa)}} deg</li>
+        <li>Position angle error: {{source.formatf(d.morph_pa_err)}} deg</li>
+        <li>Position angle frame: {{d.morph_pa_frame}}</li>
+      </ul>
+
+      <br>
+      <h4><b>Spectral Info</b></h4>
+      <ul>
+        <li>Significance: {{source.formatf(d.significance)}}</li>
+        <li>Livetime: {{source.formatf(d.livetime)}} h</li>
+        <br>
+      </ul>
+      <div id="spec" style="margin-top:-10px; margin-bottom:20px">
+        <ul>
+          {{source.get_spec_parameters()}}
+        </ul>
+      </div>
+      <ul>
+        <li>energy range min: {{source.formatp(d.spec_erange_min)}} TeV</li>
+        <li>energy range max: {{source.formatp(d.spec_erange_max)}} TeV</li>
+        <li>theta: {{source.formatp(d.spec_theta)}} deg</li>
+      </ul>
+      <p>
+        <u>Derived fluxes</u>
+      </p>
+      <ul>
+        <li>Spectral model norm (1 TeV): {{source.format_error(d.spec_dnde_1TeV, d.spec_dnde_1TeV_err)}} cm-2 s-1 TeV-1 (statistical)</li>
+        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV, d.spec_flux_1TeV_err)}} cm-2 s-1 (statistical)</li>
+        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV_crab, d.spec_flux_1TeV_crab_err)}} cm-2 s-1 (crab units)</li>
+        <li>Integrated flux (1-10 TeV): {{source.format_error(d.spec_eflux_1TeV_10TeV, d.spec_eflux_1TeV_10TeV_err)}} erg cm-2 s-1</li>
+      </ul>
+
+      <br>
+      <h4><b>Spectral Points</b></h4>
+      <ul>
+        <li>SED reference id: {{d.sed_reference_id}}</li>
+        <li>Number of spectral points: {{d.sed_n_points}}</li>
+        <li>Number of upper limits: {{d.sed_n_ul}}</li>
+      </ul>
+      <br>
+      <p>
+        <u>Flux table:</u>
+      </p>
+      <p>To be implemented</p>
 
     </div>
   </div>

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -1,11 +1,11 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{source.data.common_name}}</h3>
+      <h3>{{d.common_name}}</h3>
 
       <h5>Basic info</h5>
       <ul>
-        <li>Common name: {{source.data.common_name}}</li>
+        <li>Common name: {{d.common_name}}</li>
       </ul>
       <!-- <ul>
           <li>Common name: {{getSource().data.Source_Name}}</li>

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -32,60 +32,63 @@
         <u>SIMBAD</u>
       </p>
       <ul>
-        <li>RA: {{source.formatf(d.ra)}} deg</li>
-        <li>DEC: {{source.formatf(d.dec)}} deg</li>
-        <li>GLON: {{source.formatf(d.glon)}} deg</li>
-        <li>GLAT: {{source.formatf(d.glat)}} deg</li>
+        <li>RA: {{source.format(d.ra, false, 'deg')}}</li>
+        <li>DEC: {{source.format(d.dec, false, 'deg')}}</li>
+        <li>GLON: {{source.format(d.glon, false, 'deg')}}</li>
+        <li>GLAT: {{source.format(d.glat, false, 'deg')}}</li>
       </ul>
       <p>
         <u>Measurement</u>
       </p>
       <ul>
-        <li>RA: {{source.formatf(d.pos_ra)}} deg</li>
-        <li>DEC: {{source.formatf(d.pos_dec)}} deg</li>
-        <li>GLON: {{source.formatf(d.pos_glon)}} deg</li>
-        <li>GLAT: {{source.formatf(d.pos_glat)}} deg</li>
-        <li>Position error: {{source.formatf(d.pos_err)}} deg</li>
+        <li>RA: {{source.format(d.pos_ra, false, 'deg')}}</li>
+        <li>DEC: {{source.format(d.pos_dec, false, 'deg')}}</li>
+        <li>GLON: {{source.format(d.pos_glon, false, 'deg')}}</li>
+        <li>GLAT: {{source.format(d.pos_glat, false, 'deg')}}</li>
+        <li>Position error: {{source.format(d.pos_err, false, 'deg')}}</li>
       </ul>
 
       <br>
       <h4><b>Morphology Info</b></h4>
       <ul>
         <li>Morphology model type: {{d.morph_type}}</li>
-        <li>Sigma: {{source.formatf(d.morph_sigma)}} deg</li>
-        <li>Sigma error: {{source.formatf(d.morph_sigma_err)}} deg</li>
-        <li>Sigma2: {{source.formatf(d.morph_sigma2)}} deg</li>
-        <li>Sigma2 error: {{source.formatf(d.morph_sigma2_err)}} deg</li>
-        <li>Position angle: {{source.formatf(d.morph_pa)}} deg</li>
-        <li>Position angle error: {{source.formatf(d.morph_pa_err)}} deg</li>
+        <li>Sigma: {{source.format(d.morph_sigma, false, 'deg')}}</li>
+        <li>Sigma error: {{source.format(d.morph_sigma_err, false, 'deg')}}</li>
+        <li>Sigma2: {{source.format(d.morph_sigma2, false, 'deg')}}</li>
+        <li>Sigma2 error: {{source.format(d.morph_sigma2_err, false, 'deg')}} </li>
+        <li>Position angle: {{source.format(d.morph_pa, false, 'deg')}}</li>
+        <li>Position angle error: {{source.format(d.morph_pa_err, false, 'deg')}}
+        </li>
         <li>Position angle frame: {{d.morph_pa_frame}}</li>
       </ul>
 
       <br>
       <h4><b>Spectral Info</b></h4>
       <ul>
-        <li>Significance: {{source.formatf(d.significance)}}</li>
-        <li>Livetime: {{source.formatf(d.livetime)}} h</li>
+        <li>Significance: {{source.format(d.significance, false)}}</li>
+        <li>Livetime: {{source.format(d.livetime, false, 'h')}}</li>
         <br>
       </ul>
-      <div id="spec" style="margin-top:-10px; margin-bottom:20px">
+      <!-- <div id="spec" style="margin-top:-10px; margin-bottom:20px">
         <ul>
           {{source.get_spec_parameters()}}
         </ul>
-      </div>
+      </div> -->
       <ul>
-        <li>energy range min: {{source.formatp(d.spec_erange_min)}} TeV</li>
-        <li>energy range max: {{source.formatp(d.spec_erange_max)}} TeV</li>
-        <li>theta: {{source.formatp(d.spec_theta)}} deg</li>
+        <li>energy range min: {{source.format(d.spec_erange_min, true, 'TeV')}}
+        </li>
+        <li>energy range max: {{source.format(d.spec_erange_max, true, 'TeV')}}
+        </li>
+        <li>theta: {{source.format(d.spec_theta, true, 'deg')}}</li>
       </ul>
       <p>
         <u>Derived fluxes</u>
       </p>
       <ul>
-        <li>Spectral model norm (1 TeV): {{source.format_error(d.spec_dnde_1TeV, d.spec_dnde_1TeV_err)}} cm-2 s-1 TeV-1 (statistical)</li>
-        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV, d.spec_flux_1TeV_err)}} cm-2 s-1 (statistical)</li>
-        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV_crab, d.spec_flux_1TeV_crab_err)}} cm-2 s-1 (crab units)</li>
-        <li>Integrated flux (1-10 TeV): {{source.format_error(d.spec_eflux_1TeV_10TeV, d.spec_eflux_1TeV_10TeV_err)}} erg cm-2 s-1</li>
+        <li>Spectral model norm (1 TeV): {{source.format_error(d.spec_dnde_1TeV, d.spec_dnde_1TeV_err, true, 'cm-2 s-1 TeV-1 (stat.)')}}</li>
+        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV, d.spec_flux_1TeV_err, true, 'cm-2 s-1 (stat.)')}} </li>
+        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV_crab, d.spec_flux_1TeV_crab_err, true, 'cm-2 s-1 (crab units)')}}</li>
+        <li>Integrated flux (1-10 TeV): {{source.format_error(d.spec_eflux_1TeV_10TeV, d.spec_eflux_1TeV_10TeV_err, true, 'erg cm-2 s-1')}} </li>
       </ul>
 
       <br>

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -1,11 +1,11 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{getSource().common_name}}</h3>
+      <h3>{{source.data.common_name}}</h3>
 
       <h5>Basic info</h5>
       <ul>
-        <li>Common name: {{getSource().common_name}}</li>
+        <li>Common name: {{source.data.common_name}}</li>
       </ul>
       <!-- <ul>
           <li>Common name: {{getSource().data.Source_Name}}</li>

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -12,12 +12,14 @@
         <!-- TODO: Combine the three above into one "Other names"? -->
         <li>Location: {{d.where}}</li>
         <li>Class: {{source.comma_space(d.classes)}}</li>
-        <br>
+      </ul>
+      <ul>
         <li>TeVCat name: {{d.tevcat_name}}
           (TeVCat ID: <a href={{source.get_tevcat_url()}} target='_blank'>{{d.tevcat_id}}</a>,
           TeVCat2 ID: <a href={{source.get_tevcat2_url()}} target="_blank">{{d.tevcat2_id}}</a>)</li>
         <li>TGeVCat name: {{d.tgevcat_name}} (ID: {{d.tgevcat_id}})</li>
-        <br>
+      </ul>
+      <ul>
         <li>Discoverer: {{d.discoverer}}</li>
         <li>Discovery date: {{d.discovery_date}}</li>
         <li>Seen by: {{source.comma_space(d.seen_by)}}</li>
@@ -65,13 +67,40 @@
       <ul>
         <li>Significance: {{source.format(d.significance, false)}}</li>
         <li>Livetime: {{source.format(d.livetime, false, 'h')}}</li>
-        <br>
       </ul>
-      <!-- <div id="spec" style="margin-top:-10px; margin-bottom:20px">
+
+      <div *ngIf=show_spec_pl()>
         <ul>
-          {{source.get_spec_parameters()}}
+          <li>Spectrum type: pl</li>
+          <li>norm: {{source.format_stat_sys(d.spec_pl_norm, d.spec_pl_norm_err, d.spec_pl_norm_err_sys, true, 'cm-2 s-1 TeV-1' )}}</li>
+          <li>index: {{source.format_stat_sys(d.spec_pl_index, d.spec_pl_index_err, d.spec_pl_index_err_sys, true)}}</li>
+          <li>reference: {{source.format(d.spec_pl_e_ref, true, 'TeV')}}</li>
         </ul>
-      </div> -->
+      </div>
+      <div *ngIf=show_spec_pl2()>
+        <ul>
+          <li>Spectrum type: pl2 (integral pl)</li>
+          <li>flux: {{source.format_stat_sys(d.spec_pl2_flux, d.spec_pl2_flux_err, d.spec_pl2_flux_err_sys, true, 'cm-2 s-1')}}</li>
+          <li>index: {{source.format_stat_sys(d.spec_pl2_index, d.spec_pl2_index_err, d.spec_pl2_index_err_sys, true)}}</li>
+          <li>e_min: {{source.format(d.spec_pl2_e_min, true, 'TeV')}}</li>
+          <li>e_max: {{source.format(d.spec_pl2_e_max, true, 'TeV')}}</li>
+        </ul>
+      </div>
+      <div *ngIf=show_spec_ecpl()>
+        <ul>
+          <li>Spectrum type: ecpl</li>
+          <li>norm: {{source.format_stat_sys(d.spec_ecpl_norm, d.spec_ecpl_norm_err, d.spec_ecpl_norm_err_sys, true, 'cm-2 s-1 TeV-1')}}</li>
+          <li>index: {{source.format_stat_sys(d.spec_ecpl_index, d.spec_ecpl_index_err, d.spec_ecpl_index_err_sys, true)}}</li>
+          <li>e_cut: {{source.format_stat_sys(d.spec_ecpl_e_cut, d.spec_ecpl_e_cut_err, d.spec_ecpl_e_cut_err_sys, true, 'TeV')}}</li>
+          <li>reference: {{source.format(d.spec_ecpl_e_ref, true, 'TeV')}}</li>
+        </ul>
+      </div>
+      <div *ngIf=no_spec()>
+        <ul>
+          <li>Spectral model not yet implemented.</li>
+        </ul>
+      </div>
+
       <ul>
         <li>energy range min: {{source.format(d.spec_erange_min, true, 'TeV')}}
         </li>
@@ -84,8 +113,8 @@
       </p>
       <ul>
         <li>Spectral model norm (1 TeV): {{source.format_error(d.spec_dnde_1TeV, d.spec_dnde_1TeV_err, true, 'cm-2 s-1 TeV-1 (stat.)')}}</li>
-        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV, d.spec_flux_1TeV_err, true, 'cm-2 s-1 (stat.)')}} </li>
-        <li>Integrated flux (&lt;1 TeV): {{source.format_error(d.spec_flux_1TeV_crab, d.spec_flux_1TeV_crab_err, true, 'cm-2 s-1 (crab units)')}}</li>
+        <li>Integrated flux (&gt;1 TeV): {{source.format_error(d.spec_flux_1TeV, d.spec_flux_1TeV_err, true, 'cm-2 s-1 (stat.)')}} </li>
+        <li>Integrated flux (&gt;1 TeV): {{source.format_error(d.spec_flux_1TeV_crab, d.spec_flux_1TeV_crab_err, true, '% crab')}}</li>
         <li>Integrated flux (1-10 TeV): {{source.format_error(d.spec_eflux_1TeV_10TeV, d.spec_eflux_1TeV_10TeV_err, true, 'erg cm-2 s-1')}} </li>
       </ul>
 

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.html
@@ -6,23 +6,21 @@
       <h4><b>Basic Info</b></h4>
       <ul>
         <li>Common name: {{d.common_name}}</li>
-        <li>Gamma names: {{source.gamma_names_str()}}</li>
-        <li>Fermi names: {{source.fermi_names_str()}}</li>
-        <li>Other names: {{source.other_names_str()}}</li>
+        <li>Gamma names: {{source.comma_space(d.gamma_names)}}</li>
+        <li>Fermi names: {{source.comma_space(d.fermi_names)}}</li>
+        <li>Other names: {{source.comma_space(d.other_names)}}</li>
         <!-- TODO: Combine the three above into one "Other names"? -->
         <li>Location: {{d.where}}</li>
-        <li>Class: {{source.class_str()}}</li>
+        <li>Class: {{source.comma_space(d.classes)}}</li>
         <br>
-        <li>TeVCat ID: {{d.tevcat_id}}</li>
-        <li>TevCat2 ID: {{d.tevcat2_id}}</li>
-        <li>TeVCat name: {{d.tevcat_name}}</li>
-        <br>
-        <li>TGeVCat ID: {{d.tgevcat_id}}</li>
-        <li>TGeVCat name: {{d.tgevcat_name}}</li>
+        <li>TeVCat name: {{d.tevcat_name}}
+          (TeVCat ID: <a href={{source.get_tevcat_url()}} target='_blank'>{{d.tevcat_id}}</a>,
+          TeVCat2 ID: <a href={{source.get_tevcat2_url()}} target="_blank">{{d.tevcat2_id}}</a>)</li>
+        <li>TGeVCat name: {{d.tgevcat_name}} (ID: {{d.tgevcat_id}})</li>
         <br>
         <li>Discoverer: {{d.discoverer}}</li>
         <li>Discovery date: {{d.discovery_date}}</li>
-        <li>Seen by: {{d.seen_by}}</li>
+        <li>Seen by: {{source.comma_space(d.seen_by)}}</li>
         <li>Reference: {{d.reference_id}}</li>
       </ul>
 

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
@@ -39,14 +39,14 @@ export class CatSourceTeVComponent implements OnInit {
   ngOnInit() {
     console.log("Routing to CatSourceTeVComponent...");
 
-    this.getCatalog();
-
     this.sub = this.activatedRoute.params.subscribe(params => {
       let id = +params['id'];
       console.log('id ', id);
       this.id = id;
       this.getSource();
     });
+
+    this.getCatalog();
   }
 
   ngOnDestroy() {

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
@@ -14,6 +14,7 @@ export class CatSourceTeVComponent implements OnInit {
 
   private sub;
   private id;
+  private d;
 
   private catalog: CatalogTeV;
   private source: SourceTeV;
@@ -27,7 +28,10 @@ export class CatSourceTeVComponent implements OnInit {
 
   getSource() {
     this.catalogService.getSourceTeV(this.id)
-      .then(source => { this.source = source; })
+      .then(source => {
+        this.source = source;
+        this.d = source.data;
+      })
       .catch (error => this.error = error);
   }
 

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
@@ -26,8 +26,6 @@ export class CatSourceTeVComponent implements OnInit {
   }
 
   getSource() {
-    // return this.catalog.getSource(this.id);
-    //TODO call catalogService to get the source here, instead of fetching the source from the cat.json file.
     this.catalogService.getSourceTeV(this.id)
       .then(source => { this.source = source; })
       .catch (error => this.error = error);

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Router, ActivatedRoute } from '@angular/router';
 
 import { CatalogTeV } from '../../../services/catalog';
+import { SourceTeV } from '../../../services/source';
 import { CatalogService } from '../../../services/catalog.service';
 
 @Component({
@@ -13,9 +14,9 @@ export class CatSourceTeVComponent implements OnInit {
 
   private sub;
   private id;
-  private source;
 
   private catalog: CatalogTeV;
+  private source: SourceTeV;
   private error: any;
 
   getCatalog() {
@@ -25,7 +26,11 @@ export class CatSourceTeVComponent implements OnInit {
   }
 
   getSource() {
-    return this.catalog.getSource(this.id);
+    // return this.catalog.getSource(this.id);
+    //TODO call catalogService to get the source here, instead of fetching the source from the cat.json file.
+    this.catalogService.getSourceTeV(this.id)
+      .then(source => { this.source = source; })
+      .catch (error => this.error = error);
   }
 
   constructor(
@@ -42,6 +47,7 @@ export class CatSourceTeVComponent implements OnInit {
       let id = +params['id'];
       console.log('id ', id);
       this.id = id;
+      this.getSource();
     });
   }
 

--- a/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
+++ b/src/app/widgets/cat-source/cat-source-tev/cat-source-tev.component.ts
@@ -35,6 +35,27 @@ export class CatSourceTeVComponent implements OnInit {
       .catch (error => this.error = error);
   }
 
+  show_spec_pl() {
+    if(this.source.data.spec_type == 'pl')
+      return true;
+    return false;
+  }
+  show_spec_pl2() {
+    if(this.source.data.spec_type == 'pl2')
+      return true;
+    return false;
+  }
+  show_spec_ecpl() {
+    if(this.source.data.spec_type == 'ecpl')
+      return true;
+    return false;
+  }
+  no_spec() {
+    if(this.source.data.spec_type == 'none')
+      return true;
+    return false;
+  }
+
   constructor(
     private catalogService: CatalogService,
     private activatedRoute: ActivatedRoute


### PR DESCRIPTION
So far, I have done the following in this PR:

* Fetch individual source data from JSON source files. Access this data when you click on the specified source in `cat-search.component.ts`

* BASIC source detail view layout for TeV sources only (I still need to do the others).

@cdeil - I wanted to open the PR now so that you could have a look and tell me what to edit now. Run the `make.py` commands, call `npm start` and have a look at a TeV detail page. So far, I think I should fix the following:

1. Use spacing so that the values are all listed at the same spot vertically.
2. Any value that is `null` shows up as nothing in the HTML, but the units still show (i.e. Vela X prints `Position error: deg`). How should I fix this? Perhaps from the Python side I can just change all `NaN` values to `"null"`, instead of `null`?

Let me know if there is anything else I should fix.