### PR TITLE
Detail view for 3FHL sources

### DIFF
--- a/src/app/services/source.ts
+++ b/src/app/services/source.ts
@@ -71,6 +71,45 @@ export class SourceTeV extends SourceBase {
 
 export class Source3FHL extends SourceBase {
 
+  join_assoc() {
+    var assocs = [this.data.ASSOC1, this.data.ASSOC2, this.data.ASSOC_GAM, this.data.ASSOC_TEV];
+    for(var i = 0; i < assocs.length; i++) {
+      var a = assocs[i].trim();
+      if(a.length == 0)
+        assocs.splice(i, i++);
+    }
+    var s = assocs.join(', ');
+    return s.replace(/,\s*$/, ""); //Removes comma + any whitespace after it.
+  }
+
+  tevcat_flag() {
+    var flag = this.data.TEVCAT_FLAG;
+    if(flag == 'N')
+      return "No TeV association";
+    else if(flag == 'P')
+      return "Small TeV source";
+    else if(flag == 'E')
+      return "Extended TeV source (diameter > 40 arcmins)";
+    else
+      return "N/A";
+  }
+
+  bayesian_blocks() {
+    var bayesBlocks = this.data.Variability_BayesBlocks;
+    var msg;
+    if(bayesBlocks == 1)
+      msg = '1 (not variable)';
+    else if(bayesBlocks == -1)
+      msg = 'Could not be tested';
+    else
+      msg = bayesBlocks.toString();
+    return msg;
+  }
+
+  is_extended() {
+    return this.data.Extended_Source_Name.trim() != '';
+  }
+
 }
 
 export class Source3FGL extends SourceBase {

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
@@ -14,7 +14,7 @@
       </ul>
       <ul>
         <li>Significance (10 GeV - 2 TeV): {{source.format(d.Signif_Avg, false)}}</li>
-        <li>Npred: {{source.format(d.Npred, true)}}</li>
+        <li>Predicted n. events in model: {{source.format(d.Npred, true)}}</li>
       </ul>
 
       <br>
@@ -51,7 +51,7 @@
         <li *ngIf=isLogParabola()>beta: {{source.format_error(d.beta, d.Unc_beta, false)}}</li>
         <li>Pivot energy: {{source.format(d.Pivot_Energy, true, 'GeV')}}</li>
         <li>Power law index: {{source.format_error(d.PowerLaw_Index, d.Unc_PowerLaw_Index, false)}}</li>
-        <li>Flux density at pivot energy: {{source.format_error(d.Flux_Density, d.Unc_Flux_Density, true, 'cm-2 GeV-1 s-1')}}</li>
+        <li>Flux density at pivot energy: {{source.format_error(d.Flux_Density, d.Unc_Flux_Density, true, 'cm-2 s-1 GeV-1')}}</li>
         <li>Integral flux (10 GeV - 1 TeV): {{source.format_error(d.Flux, d.Unc_Flux, true, 'cm-2 s-1')}}</li>
         <li>Energy flux (10 GeV - 1 TeV): {{source.format_error(d.Energy_Flux, d.Unc_Energy_Flux, true, 'erg cm-2 s-1')}}</li>
       </ul>
@@ -65,8 +65,7 @@
       <br>
       <h4><b>Other Info</b></h4>
       <ul>
-        <li>HEP energy: {{source.format(d.HEP_Energy, false, 'GeV')}}</li>
-        <li>HEP probability: {{source.format(d.HEP_Prob, false)}}</li>
+        <li>Highest energy photon: {{source.format(d.HEP_Energy, false, 'GeV')}} (Probability: {{source.format(d.HEP_Prob * 100, true)}}%)</li>
         <li>Bayesian Blocks: {{source.bayesian_blocks()}}</li>
         <li>Redshift: {{source.format(d.Redshift, false)}}</li>
         <li>NuPeak_obs: {{source.format(d.NuPeak_obs, true, 'Hz')}}</li>

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.html
@@ -1,10 +1,75 @@
 <div *ngIf="(catalog)">
   <div class="container">
     <div class="col-md-6">
-      <h3>{{d.Source_Name}}</h3>
-      <h5>Basic info: </h5>
+      <h2>{{d.Source_Name}}</h2><br>
+
+      <h4><b>Basic Info</b></h4>
       <ul>
         <li>Source name: {{d.Source_Name}}</li>
+        <li>Extended name: {{d.Extended_Source_Name}}</li>
+        <li>Associations: {{source.join_assoc()}}</li>
+        <li>Association probability: {{source.format(d.ASSOC_PROB_BAY, false)}} (Bayesian), {{source.format(d.ASSOC_PROB_LR)}} (Likelihood Ratio)</li>
+        <li>Class: {{d.CLASS}}</li>
+        <li>TeVCat flag: {{source.tevcat_flag()}}</li>
+      </ul>
+      <ul>
+        <li>Significance (10 GeV - 2 TeV): {{source.format(d.Signif_Avg, false)}}</li>
+        <li>Npred: {{source.format(d.Npred, true)}}</li>
+      </ul>
+
+      <br>
+      <h4><b>Position Info</b></h4>
+      <ul>
+        <li>RA: {{source.format(d.RAJ2000, false, 'deg')}}</li>
+        <li>DEC: {{source.format(d.DEJ2000, false, 'deg')}}</li>
+        <li>GLON: {{source.format(d.GLON, false, 'deg')}}</li>
+        <li>GLAT: {{source.format(d.GLAT, false, 'deg')}}</li>
+      </ul>
+      <ul>
+        <li>Semimajor (95%): {{source.format(d.Conf_95_SemiMajor, false, 'deg')}}</li>
+        <li>Semiminor (95%): {{source.format(d.Conf_95_SemiMinor, false, 'deg')}}</li>
+        <li>Position angle (95%): {{source.format(d.Conf_95_PosAng, true, 'deg')}}</li>
+        <li>ROI number: {{d.ROI_num}}</li>
+      </ul>
+
+      <br>
+      <h4><b>Model Info</b></h4>
+
+      <div *ngIf=isExtended()>
+        <p>
+          <u>Extended source information</u>
+        </p>
+        <p>
+          (To be implemented)
+        </p>
+      </div>
+
+      <ul>
+        <li>Spectrum type: {{d.SpectrumType}}</li>
+        <li>Significance curvature: {{source.format(d.Signif_Curve, true)}}</li>
+        <li>Spectral index: {{source.format_error(d.Spectral_Index, d.Unc_Spectral_Index, false)}}</li>
+        <li *ngIf=isLogParabola()>beta: {{source.format_error(d.beta, d.Unc_beta, false)}}</li>
+        <li>Pivot energy: {{source.format(d.Pivot_Energy, true, 'GeV')}}</li>
+        <li>Power law index: {{source.format_error(d.PowerLaw_Index, d.Unc_PowerLaw_Index, false)}}</li>
+        <li>Flux density at pivot energy: {{source.format_error(d.Flux_Density, d.Unc_Flux_Density, true, 'cm-2 GeV-1 s-1')}}</li>
+        <li>Integral flux (10 GeV - 1 TeV): {{source.format_error(d.Flux, d.Unc_Flux, true, 'cm-2 s-1')}}</li>
+        <li>Energy flux (10 GeV - 1 TeV): {{source.format_error(d.Energy_Flux, d.Unc_Energy_Flux, true, 'erg cm-2 s-1')}}</li>
+      </ul>
+
+      <br>
+      <h4><b>Spectral Points</b></h4>
+      <p>
+        (To be implemented)
+      </p>
+
+      <br>
+      <h4><b>Other Info</b></h4>
+      <ul>
+        <li>HEP energy: {{source.format(d.HEP_Energy, false, 'GeV')}}</li>
+        <li>HEP probability: {{source.format(d.HEP_Prob, false)}}</li>
+        <li>Bayesian Blocks: {{source.bayesian_blocks()}}</li>
+        <li>Redshift: {{source.format(d.Redshift, false)}}</li>
+        <li>NuPeak_obs: {{source.format(d.NuPeak_obs, true, 'Hz')}}</li>
       </ul>
     </div>
   </div>

--- a/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
+++ b/src/app/widgets/cat-source/cat-source-3fhl/cat-source-3fhl.component.ts
@@ -35,6 +35,15 @@ export class CatSource3FHLComponent implements OnInit {
       .catch (error => this.error = error);
   }
 
+  isExtended() {
+    return this.source.is_extended();
+  }
+  isLogParabola() {
+    if(this.d.SpectrumType.trim() == 'LogParabola')
+      return true;
+    return false;
+  }
+
   constructor(
     private catalogService: CatalogService,
     private activatedRoute: ActivatedRoute


### PR DESCRIPTION
@cdeil - In this PR I filled out the detail view for 3FHL sources. This is what it currently looks like:

![ss](https://user-images.githubusercontent.com/18579919/28204080-bf725410-687c-11e7-9b3b-4e5b63c724e0.PNG)

Let me know what can be changed/reformatted.

Also - for extended 3FHL sources, we need to load additional data from Gammapy (`SourceCatalog3FHL().data_extended`) to fill for their detail pages in gamma-sky.net. I can do that later and add the commit to this PR.