### PR TITLE
Event listeners to update map url

### DIFF
--- a/src/app/widgets/map/map.component.ts
+++ b/src/app/widgets/map/map.component.ts
@@ -18,7 +18,8 @@ declare let CooConversion: any;
 
 @Component({
   selector: 'app-map',
-  template: `<div id="aladin-lite-div"></div>`,
+  template: `<div id="aladin-lite-div" (mouseup)="updateUrl()"></div>`,
+  // (scroll) event not working? https://github.com/angular/angular/issues/17015
   styleUrls: ['./map.component.css']
 })
 export class MapComponent implements OnInit, OnDestroy {


### PR DESCRIPTION
Added an event listener `(mouseup)` that will essentially detect when you lift your finger up from the mouse button on the Aladin Lite widget. This updates the URL to the current ra/dec you're looking at. I tried to do the same by adding a `(scroll)` event, but it seems to not be working. Perhaps it can be implemented in the future.